### PR TITLE
Handle ivy-read calling ivy-mdfind-function without argument

### DIFF
--- a/spotlight.el
+++ b/spotlight.el
@@ -138,10 +138,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Function to be called by ivy to run mdfind
-(defun ivy-mdfind-function (string &rest _unused)
+(defun ivy-mdfind-function (&optional string &rest _unused)
   "Issue mdfind for STRING."
+  (if (not (boundp 'string)) (setq string ""))
   (if (< (length string) spotlight-min-chars)
-      (counsel-more-chars spotlight-min-chars)
+      (counsel-more-chars)
     (spotlight-async-command
      (concat "mdfind -onlyin "
              (shell-quote-argument

--- a/spotlight.el
+++ b/spotlight.el
@@ -140,7 +140,6 @@
 ;; Function to be called by ivy to run mdfind
 (defun ivy-mdfind-function (&optional string &rest _unused)
   "Issue mdfind for STRING."
-  (if (not (boundp 'string)) (setq string ""))
   (if (< (length string) spotlight-min-chars)
       (counsel-more-chars)
     (spotlight-async-command


### PR DESCRIPTION
Recent `ivy-read` will pass nothing if it hasn't read input. This caused calling `spotlight` interactively to fail.

* Make `string` optional in `ivy-mdfind-function`, allowing `ivy-read`'s behavior
* `counsel-more-chars` takes no arguments, correcting this as well