### PR TITLE
update to work with recent versions of ivy

### DIFF
--- a/spotlight.el
+++ b/spotlight.el
@@ -109,6 +109,8 @@
 (defvar spotlight-file-filter-flag nil
   "Flag to record if filename filtering is requested.")
 
+(ivy-configure 'spotlight :more-chars spotlight-min-chars)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; functions                                                              ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -140,17 +142,16 @@
 ;; Function to be called by ivy to run mdfind
 (defun ivy-mdfind-function (string &rest _unused)
   "Issue mdfind for STRING."
-  (if (< (length string) spotlight-min-chars)
-      (counsel-more-chars spotlight-min-chars)
-    (spotlight-async-command
-     (concat "mdfind -onlyin "
-             (shell-quote-argument
-              (expand-file-name spotlight-user-base-dir))
-             " "
-             (shell-quote-argument string)
-             " > "
-             (expand-file-name spotlight-tmp-file)))
-    '("" "working...")))
+  (or (ivy-more-chars)
+      (progn (spotlight-async-command
+              (concat "mdfind -onlyin "
+                      (shell-quote-argument
+                       (expand-file-name spotlight-user-base-dir))
+                      " "
+                      (shell-quote-argument string)
+                      " > "
+                      (expand-file-name spotlight-tmp-file)))
+             '("" "working..."))))
 
 ;; Modified version of counsel--async-command from counsel.el
 (defun spotlight-async-command (cmd)
@@ -266,7 +267,8 @@ base directory to search below, otherwise it will use
                           ;;else open file
                           (progn (setq spotlight-file-filter-flag nil)
                                  (find-file x)
-                                 (swiper ivy-text)))))))
+                                 (swiper ivy-text))))
+              :caller 'spotlight)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; spotlight-fast                                                         ;;


### PR DESCRIPTION
At some point `(ivy-more-chars)` changed. This updates the package. Cheers!